### PR TITLE
Adjusting ART initiation rates from never tested

### DIFF
--- a/R/eppasm.R
+++ b/R/eppasm.R
@@ -402,18 +402,34 @@ simmod.specfp <- function(fp, VERSION="C"){
         }
 
         if(i >= fp$t_hts_start){
+          # ---- PROPOSITION ----- 
+          # 'newdiagn' is an array that contains how many new diagnoses are in deficit in the diagnosed population to match ART initiations
           newdiagn <- pmax(artinit - diagnpop[,,,i], 0)
-
-          ## Remove share of excess ART initiations from testnegpop
-          ## elig_idx <- fp$artcd4elig_idx[i]:hDS
-          ## prop_testneg <- testnegpop[ , , hivp.idx, i] / colSums(hivpop[elig_idx,,,i] - diagnpop[elig_idx,,,i])
-
+          # 'prop_testneg' calculates the ratio of individuals in the hiv+ testnegpop as compared to the hiv+ never tested group
+          # (is that the correct interpretation?)
           prop_testneg <- testnegpop[ , , hivp.idx, i] / colSums(hivpop[,,,i] - diagnpop[,,,i])
-
+          # here, the 'testnegpop' now becomes aware according to their relative proportion.
           testnegpop[ , , hivp.idx, i] <- testnegpop[ , , hivp.idx, i] - prop_testneg * colSums(newdiagn)
           late_diagnoses[,,,i] <- late_diagnoses[,,,i] + newdiagn
           diagnoses[,,,i] <- diagnoses[,,,i] + newdiagn
+          # Here, we remove from the diagnpop the artinitiation (minus the late diagnoses)
           diagnpop[,,,i] <- diagnpop[,,,i] - (artinit - newdiagn)
+          # To not artificially inflate awareness, we substitute back those late diagnoses from those in available CD4 cell count categories.
+          diagn_deficit <- pmax(artinit - diagnpop[,,,i], 0)
+          diagn_surplus <- pmax(diagnpop[,,,i] - artinit, 0)
+            frac_exc <- array(0, c(hDS, hAG, 2))
+            frac_exc[,,1] <- matrix(rep(colSums(diagn_deficit[,,1]) / colSums(diagn_surplus[,,1]), each = hDS),
+                                    nrow = hDS, ncol = hAG)
+            frac_exc[,,2] <- matrix(rep(colSums(diagn_deficit[,,2]) / colSums(diagn_surplus[,,2]), each = hDS),
+                                    nrow = hDS, ncol = hAG)
+          # We only substitute back if there is enough people 
+          frac_exc[!is.finite(frac_exc)] <- 0
+          frac_exc[frac_exc > 1] <- 1
+          to_put_back <- diagn_surplus[,,] * frac_exc
+          diagnpop[,,,i] <- diagnpop[,,,i] - to_put_back
+          testnegpop[ , , hivp.idx, i] <- testnegpop[ , , hivp.idx, i] + prop_testneg * colSums(to_put_back)
+          late_diagnoses[,,,i] <- late_diagnoses[,,,i] - to_put_back
+          diagnoses[,,,i] <- diagnoses[,,,i] - to_put_back
         }
 
         hivpop[, h.age15plus.idx,, i] <- hivpop[, h.age15plus.idx,, i] - artinit

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -947,12 +947,29 @@ extern "C" {
 		  artinits[t][g][ha][hm] += artinit_hahm;
                 }
 
-		// Remove share of excess ART initiations from testnegpop
+		// Remove share of excess ART initiations from either diagnpop or testnegpop
 		if(t >= t_hts_start & new_diagn_ha > 0){
-		  double new_among_testneg = new_diagn_ha * testnegpop[t][HIVP][g][ha] / undiagnosed_ha;
-		  hivtests[t][2][g][ha] += new_diagn_ha - new_among_testneg; // new diagnoses among never tested
-		  hivtests[t][3][g][ha] += new_among_testneg;
-		  testnegpop[t][HIVP][g][ha] -= new_among_testneg;
+
+		  double diagn_surplus_ha = 0.0;
+		  for(int hm = 0; hm < hDS; hm++)
+		    diagn_surplus_ha += diagnpop[t][g][ha][hm];
+
+		  double prop_put_back = new_diagn_ha < diagn_surplus_ha ? new_diagn_ha / diagn_surplus_ha : 1.0;
+		  for(int hm = 0; hm < hDS; hm++) {
+		    double put_back = prop_put_back * diagnpop[t][g][ha][hm];
+		    diagnpop[t][g][ha][hm] -= put_back;
+		    diagnoses[t][g][ha][hm] -= put_back;
+		    late_diagnoses[t][g][ha][hm] -= put_back;
+		  }
+
+		  if(new_diagn_ha > diagn_surplus_ha){
+		    new_diagn_ha -= diagn_surplus_ha;
+
+		    double new_among_testneg = new_diagn_ha * testnegpop[t][HIVP][g][ha] / undiagnosed_ha;
+		    hivtests[t][2][g][ha] += new_diagn_ha - new_among_testneg; // new diagnoses among never tested
+		    hivtests[t][3][g][ha] += new_among_testneg;
+		    testnegpop[t][HIVP][g][ha] -= new_among_testneg;
+		  }
 		}
 
 	      } // end loop over ha
@@ -987,12 +1004,29 @@ extern "C" {
 		  artinits[t][g][ha][hm] += artinit_hahm;
                 }
 
-		// Remove share of excess ART initiations from testnegpop
+		// Remove share of excess ART initiations from either diagnpop or testnegpop
 		if(t >= t_hts_start & new_diagn_ha > 0){
-		  double new_among_testneg = new_diagn_ha * testnegpop[t][HIVP][g][ha] / undiagnosed_ha;
-		  hivtests[t][2][g][ha] += new_diagn_ha - new_among_testneg; // new diagnoses among never tested
-		  hivtests[t][3][g][ha] += new_among_testneg;
-		  testnegpop[t][HIVP][g][ha] -= new_among_testneg;
+
+		  double diagn_surplus_ha = 0.0;
+		  for(int hm = 0; hm < hDS; hm++)
+		    diagn_surplus_ha += diagnpop[t][g][ha][hm];
+
+		  double prop_put_back = new_diagn_ha < diagn_surplus_ha ? new_diagn_ha / diagn_surplus_ha : 1.0;
+		  for(int hm = 0; hm < hDS; hm++) {
+		    double put_back = prop_put_back * diagnpop[t][g][ha][hm];
+		    diagnpop[t][g][ha][hm] -= put_back;
+		    diagnoses[t][g][ha][hm] -= put_back;
+		    late_diagnoses[t][g][ha][hm] -= put_back;
+		  }
+
+		  if(new_diagn_ha > diagn_surplus_ha){
+		    new_diagn_ha -= diagn_surplus_ha;
+
+		    double new_among_testneg = new_diagn_ha * testnegpop[t][HIVP][g][ha] / undiagnosed_ha;
+		    hivtests[t][2][g][ha] += new_diagn_ha - new_among_testneg; // new diagnoses among never tested
+		    hivtests[t][3][g][ha] += new_among_testneg;
+		    testnegpop[t][HIVP][g][ha] -= new_among_testneg;
+		  }
 		}
 
 	      } // end loop over ha


### PR DESCRIPTION
In cases where there was not enough diagnosed PLHIV of a given sex/age/CD4 count category to recruit on treatment, we previoulsy took them from the _undiagnosed_ population. Here, I move back to _undiagnosed_ an equivalent number of people from the _diagnosed_ (proportional to their availability), but in higher CD4 cell count categories.