### PR TITLE
add survey ART coverage to likelihood; bump version eppasm_v0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eppasm
 Title: Age-structured EPP Model for HIV Epidemic Estimates
-Version: 0.5.10
+Version: 0.6.0
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 Depends: R (>= 3.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## eppasm 0.6.0
+
+* Add likelihood for survey ART coverage.
+
+
 ## eppasm 0.5.10
 
 * Patch `read_epp_t0()` to parse XML file projection sets using same code as `epp:read_epp_data()`. This resolves parsing issue for Niger, Senegal, and Dominican Republic. Unsure why the XML is formed different for these cases.

--- a/vignettes_src/eppasm-basic-example.Rmd
+++ b/vignettes_src/eppasm-basic-example.Rmd
@@ -81,6 +81,26 @@ prev(modR)
 incid(modR)
 ```
 
+Add survey ART coverage data.
+
+```{r, add_artcov_dat
+attr(bw$Urban, "eppd")$hhsartcov <- data.frame(year = 2012,
+                                               sex = "both",
+                                               agegr = "15-49",
+                                               n = 764,
+                                               artcov = 0.397,
+                                               se = 0.024,
+                                               used = TRUE)
+
+attr(bw$Urban, "eppd")$hhsartcov <- data.frame(year = 2012,
+                                               sex = "both",
+                                               agegr = "15-49",
+                                               n = 484,
+                                               artcov = 0.397,
+                                               se = 0.034,
+                                               used = TRUE)
+
+```
 
 Prepare likelihood and calculate the likelihood once
 


### PR DESCRIPTION
This PR:
* Adds survey ART coverage to the likelihood
  * This was implemented in EPP/Spectrum for 2022 HIV estimates round
* Bump version number 0.6.0

Additional tools may be required to extract ART programme data inputs / ART allocation from .PJNZ files