### PR TITLE
use `deff` for `n_eff` in zero prevalence binom likelihood

### DIFF
--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -315,7 +315,7 @@ prepare_hhsageprev_likdat <- function(hhsage, fp){
 
   if(exists("deff_approx", hhsage))
     hhsage$n_eff <- hhsage$n/hhsage$deff_approx
-  else if(exists("deff_approx", hhsage))
+  else if(exists("deff", hhsage))
     hhsage$n_eff <- hhsage$n/hhsage$deff
   else
     hhsage$n_eff <- hhsage$prev * (1 - hhsage$prev) / hhsage$se ^ 2


### PR DESCRIPTION
with this I could run pass BEN data with zero prevalence  (zero SE) in 15-19 year-old. Is this correct?

(cherry picked from commit 57a7a9ae2f81148abbd537e01cf287f82453dc71)