### PR TITLE
align calculation of new infections by age with Spectrum for direct incidence option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eppasm
 Title: Age-structured EPP Model for HIV Epidemic Estimates
-Version: 0.6.1
+Version: 0.6.3
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 Depends: R (>= 3.1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eppasm
 Title: Age-structured EPP Model for HIV Epidemic Estimates
-Version: 0.6.3
+Version: 0.6.2
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 Depends: R (>= 3.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,8 @@
-## eppasm 0.6.3
+## eppasm 0.6.2
 
 * Distribute age incidence rate ratio using **current** year HIV population by time step, instead of previous year HIV population to match Spectrum calculation. 
   - Calculation of incidence rate by sex uses **previous** year HIV negative population
   - Thanks Rob Glaubius for debugging: https://github.com/mrc-ide/leapfrog/issues/18
-  
-## eppasm 0.6.2
-
-* Distribute age incidence rate ratio using **current** year HIV population by time step, instead of previous year HIV population to match Spectrum calculation. (Thanks Rob Glaubius for debugging.)
 
 ## eppasm 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## eppasm 0.6.3
+
+* Distribute age incidence rate ratio using **current** year HIV population by time step, instead of previous year HIV population to match Spectrum calculation. 
+  - Calculation of incidence rate by sex uses **previous** year HIV negative population
+  - Thanks Rob Glaubius for debugging: https://github.com/mrc-ide/leapfrog/issues/18
+  
+## eppasm 0.6.2
+
+* Distribute age incidence rate ratio using **current** year HIV population by time step, instead of previous year HIV population to match Spectrum calculation. (Thanks Rob Glaubius for debugging.)
+
 ## eppasm 0.6.1
 
 * For direct incidence input, create new option `DIRECTINCID_HTS` for intercalating direct incidence new HIV infections in each time step. This was implemented by (1) calculating the number of new infections once per year before the HIV simulation, then (2) adding DT * new infections in each time step. 

--- a/R/eppasm.R
+++ b/R/eppasm.R
@@ -157,8 +157,6 @@ simmod.specfp <- function(fp, VERSION="C"){
       incrate.i <- fp$incidinput[i]
       
       sexinc <- incrate.i*c(1, fp$incrr_sex[i])*sum(pop[p.incidpop.idx,,hivn.idx,i-1])/(sum(pop[p.incidpop.idx,m.idx,hivn.idx,i-1]) + fp$incrr_sex[i]*sum(pop[p.incidpop.idx, f.idx,hivn.idx,i-1]))
-      agesex.inc <- sweep(fp$incrr_age[,,i], 2, sexinc/(colSums(pop[p.incidpop.idx,,hivn.idx,i-1] * fp$incrr_age[p.incidpop.idx,,i])/colSums(pop[p.incidpop.idx,,hivn.idx,i-1])), "*")
-      infections_i <- agesex.inc * pop[,,hivn.idx,i-1]
     }
 
     ## events at dt timestep
@@ -187,9 +185,11 @@ simmod.specfp <- function(fp, VERSION="C"){
           incrate15to49.ts.out[ts] <- attr(infections.ts, "incrate15to49.ts")
           prev15to49.ts.out[ts] <- attr(infections.ts, "prevcurr")
           prevlast <- attr(infections.ts, "prevcurr")
+
         } else {
           ## eppmod == directincid_hts
-          infections.ts <- infections_i
+          agesex.inc <- sweep(fp$incrr_age[,,i], 2, sexinc/(colSums(pop[p.incidpop.idx,,hivn.idx,i] * fp$incrr_age[p.incidpop.idx,,i])/colSums(pop[p.incidpop.idx,,hivn.idx,i-1])), "*")
+          infections.ts <- agesex.inc * pop[,,hivn.idx,i]
         }
         
         pop[,,hivn.idx,i] <- pop[,,hivn.idx,i] - DT*infections.ts
@@ -370,7 +370,8 @@ simmod.specfp <- function(fp, VERSION="C"){
 
     ## Direct incidence input
     if(fp$eppmod == "directincid_ann"){
-      infections[,,i] <- infections_i
+      agesex.inc <- sweep(fp$incrr_age[,,i], 2, sexinc/(colSums(pop[p.incidpop.idx,,hivn.idx,i] * fp$incrr_age[p.incidpop.idx,,i])/colSums(pop[p.incidpop.idx,,hivn.idx,i-1])), "*")
+      infections[,,i] <- agesex.inc * pop[,,hivn.idx,i]
       pop[,,hivn.idx,i] <- pop[,,hivn.idx,i] - infections[,,i]
       pop[,,hivp.idx,i] <- pop[,,hivp.idx,i] + infections[,,i]
       

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -556,36 +556,6 @@ extern "C" {
       everARTelig_idx = anyelig_idx < everARTelig_idx ? anyelig_idx : everARTelig_idx;
 
       double infections_ts[NG][pAG];
-
-      if(eppmod == EPP_DIRECTINCID_ANN ||
-         eppmod == EPP_DIRECTINCID_HTS ) {
-        
-	// Calculating new infections once per year (like Spectrum)
-	
-	double Xhivp = 0.0, Xhivn[NG], Xhivn_incagerr[NG];
-	
-	for(int g = 0; g < NG; g++){
-	  Xhivn[g] = 0.0;
-	  Xhivn_incagerr[g] = 0.0;
-	  for(int a = pIDX_INCIDPOP; a < pIDX_INCIDPOP+pAG_INCIDPOP; a++){
-	    Xhivp += pop[t-1][HIVP][g][a];
-	    Xhivn[g] += pop[t-1][HIVN][g][a];
-	    Xhivn_incagerr[g] += incrr_age[t][g][a] * pop[t-1][HIVN][g][a];
-	  }
-	}
-	// double prev_i = Xhivp / (Xhivn[MALE] + Xhivn[FEMALE] + Xhivp);
-	// double incrate15to49_i = (prev15to49[t] - prev_i)/(1.0 - prev_i);
-	double incrate_i = incidinput[t];
-	double incrate_g[NG];
-	incrate_g[MALE] = incrate_i * (Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
-	incrate_g[FEMALE] = incrate_i * incrr_sex[t]*(Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
-        
-	for(int g = 0; g < NG; g++) {
-          for(int a = 0; a < pAG; a++) {
-            infections_ts[g][a] = pop[t-1][HIVN][g][a] * incrate_g[g] * incrr_age[t][g][a] * Xhivn[g] / Xhivn_incagerr[g];
-          }
-        }
-      }
       
       for(int hts = 0; hts < HIVSTEPS_PER_YEAR; hts++){
 
@@ -645,6 +615,31 @@ extern "C" {
           
             prev15to49_ts_out[ts] = prevcurr;
           }
+
+        if(eppmod == EPP_DIRECTINCID_ANN || eppmod == EPP_DIRECTINCID_HTS ) {        
+          // Calculating new infections once per year (like Spectrum)
+          double Xhivp = 0.0, Xhivn[NG], Xhivn_incagerr[NG];
+	
+	        for(int g = 0; g < NG; g++) {
+	          Xhivn[g] = 0.0;
+	          Xhivn_incagerr[g] = 0.0;
+	          for(int a = pIDX_INCIDPOP; a < pIDX_INCIDPOP+pAG_INCIDPOP; a++) {
+	            Xhivp += pop[t-1][HIVP][g][a];
+	            Xhivn[g] += pop[t-1][HIVN][g][a];
+	            Xhivn_incagerr[g] += incrr_age[t][g][a] * pop[t][HIVN][g][a];
+	          }
+	        }
+	        double incrate_i = incidinput[t];
+	        double incrate_g[NG];
+	        incrate_g[MALE] = incrate_i * (Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
+	        incrate_g[FEMALE] = incrate_i * incrr_sex[t]*(Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
+        
+	        for(int g = 0; g < NG; g++) {
+            for(int a = 0; a < pAG; a++) {
+              infections_ts[g][a] = pop[t][HIVN][g][a] * incrate_g[g] * incrr_age[t][g][a] * Xhivn[g] / Xhivn_incagerr[g];
+            }
+          }
+        }
 
           // add new infections to HIV population
           for(int g = 0; g < NG; g++){


### PR DESCRIPTION
This addresses discrepancy between new infections by age between Spectrum and EPP-ASM direct incidence option described here: https://github.com/mrc-ide/leapfrog/issues/18

* Total new infections age 15-49 and Incidence rate by sex is calculated using HIV-negative population at year `t-1`
* _New infections by single-year age are calculated based on population in current year `t` at each time-step._

This change does _not_ affect:

* EPP (java implementation) because incidence is calculate per time-step based on r(t), including an adjustment to the 15-49 population for the number of steps into the year.
* Shiny90: Shiny90 takes the exact number of infections by age from Spectrum (not incidence rates).

It might affect CSAVR.

Thanks @rlglaubius.