### PR TITLE
patch: net-migration in artpop in first ART year

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eppasm
 Title: Age-structured EPP Model for HIV Epidemic Estimates
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 Depends: R (>= 3.1.0),
@@ -29,4 +29,4 @@ Suggests:
 VignetteBuilder: knitr
 URL: https://github.com/mrc-ide/eppasm
 BugReports: https://github.com/mrc-ide/eppasm/issues
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## eppasm 0.7.3
+
+* Bug fix: account for end-year net migration in the ART population in the first year of ART start.
+
 ## eppasm 0.7.2
 
 * Add function `read_pop1()` to parse Spectrum `_pop1.xlsx` export file. 

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -981,7 +981,7 @@ extern "C" {
 	    double migrate_ha = hivpop_ha > 0 ? mig_ha / hivpop_ha : 0.0;
 	    for(int hm = 0; hm < hDS; hm++){
 	      hivpop[t][g][ha][hm] *= 1+migrate_ha;
-	      if(t > t_ART_start)
+	      if(t >= t_ART_start)
 		for(int hu = 0; hu < hTS; hu++)
 		  artpop[t][g][ha][hm][hu] *= 1+migrate_ha;
 	    } // loop over hm


### PR DESCRIPTION
There was a small error in the update to end-year net migration. It was only applied if `t > t_ART_start`, which was copied from when net migration occurred before the HIV model simulation.  When it occurs after the HIV model simulation, this needs to be `t >= t_ART_start`.

In practice, this is of minimal consequence as the number on ART in the first year is small and net migration relatively small But it creates a discrepancy between the single-age HIV population and the sum of `hivpop` and `artpop`.