### PR TITLE
ART input adjustment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eppasm
 Title: Age-structured EPP Model for HIV Epidemic Estimates
-Version: 0.8.0
+Version: 0.8.1
 Authors@R: person("Jeff", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
 Depends: R (>= 3.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## epapsm 0.8.1
+
+* Implement Spectrum Adult ART scalar adjustment. This is a user input that 
+  allows the input number on ART to be adjusted by a scalar to account for 
+  over/under-reporting of treatment numbers.
+	
 ## eppasm 0.8.0
 
 * Implement Spectrum ART allocation.


### PR DESCRIPTION
Implement Spectrum Adult ART scalar adjustment. This is a user input that allows the input number on ART to be adjusted by a scalar to account for over/under-reporting of treatment numbers.