### PR TITLE
Add option to simulate and fit model with leapfrog

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Suggests:
 VignetteBuilder: knitr
 URL: https://github.com/mrc-ide/eppasm
 BugReports: https://github.com/mrc-ide/eppasm/issues
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3

--- a/R/leapfrog.R
+++ b/R/leapfrog.R
@@ -1,0 +1,237 @@
+#' Convert eppasm fp object into leapfrog parameters
+#'
+#' @param fp eppasm fixed parameters
+#'
+#' @returns Parameters organised for running leapfrog coarse age model
+#' @noRd
+fp_to_leapfrog_params <- function(fp) {
+  ## TODO: this is working with output from `prepare_spec_fit`
+  # support direct incid input too i.e. from prepare_directincid
+
+  births_sex_prop_male <- fp$srb / (fp$srb + 100)
+  births_sex_prop <- rbind(male = births_sex_prop_male,
+                           female = 1 - births_sex_prop_male)
+  year_end <- fp$ss$proj_start + fp$SIM_YEARS
+
+  if (fp$eppmod %in% c("rspline", "logrw", "rhybrid", "rlogistic")) {
+    incidence_model_choice <- 1L
+    incid_input <- rep(0, fp$SIM_YEARS + 1)
+    # rvec here is different to what is required by leapfrog in a few ways
+    # for rhybrid it can have duplicate years when the curve switches types
+    # So for a fit starting in 1970.5 until 2018.5 with SIM_YEARS of 48
+    # It can e.g. have data for 1970.5, 1970.6, ..., 2002.9, 2003.0, 2003.0,
+    # 2003.1, ..., 2017.3, 2017.4, 2017.5 giving us 472 data points
+    # But leapfrog expects SIM_YEARS * hiv_steps_per_year inputs for
+    # transmission rate. We are 8 short. Repeat the first entry 8 additional
+    # times for now to get the right length
+    required_length <- fp$SIM_YEARS * fp$ss$hiv_steps_per_year
+    pad_num <- required_length - length(fp$rvec)
+    if (pad_num < 0) {
+      stop("Input transmission data is longer than expected, not supported with leapfrog.")
+    }
+    transmission_rate_hts <- c(rep(fp$rvec[1], pad_num), fp$rvec)
+    initial_incidence <- fp$iota
+    epidemic_start_hts <- fp$ss$time_epi_start
+    relative_infectiousness_art <- fp$relinfectART
+    pAG_INCIDPOP <- 0
+  } else if (fp$eppmod %in% c("directincid_ann", "directincid_hts")) {
+    incidence_model_choice <- 0L
+    incid_input <- fp$incidinput
+    transmission_rate_hts <- rep(0, fp$SIM_YEARS * fp$ss$hiv_steps_per_year)
+    initial_incidence <- 0
+    epidemic_start_hts <- 0
+    relative_infectiousness_art <- 0
+    pAG_15_to_49 <- 35L
+    pAG_15_plus <- 66L
+    pAG_INCIDPOP <- ifelse(fp$incidpopage == 0L, pAG_15_to_49, pAG_15_plus)
+  } else if (fp$eppmod == "rtrend") {
+    stop("eppmod 'rtrend' not supported with leapfrog, try a different eppmod")
+  } else {
+    stop(sprintf(
+      "Cannot run with unknown eppmod '%s'. Check documentation for valid values.",
+      fp$eppmod
+    ))
+  }
+
+  leapfrog_params <- list(
+    projection_start_year = fp$ss$proj_start,
+    projection_period = fp$projection_period,
+    t_ART_start = min(c(unlist(apply(fp$art15plus_num > 0, 1, which)), fp$SIM_YEARS)),
+    # We can only simulate up to when we have data, so PROJ_YEARS and SIM_YEARS
+    # can be different. If more proj_years then we will project forward as a
+    # 2nd step. Pad the data to correct length for now.
+    proj_years = fp$ss$PROJ_YEARS,
+    sim_years = fp$SIM_YEARS,
+    basepop = fp$basepop_allage,
+    Sx = fp$Sx_allage,
+    netmigr_adj = fp$netmigr_adj,
+    asfr = fp$asfr,
+    births_sex_prop = births_sex_prop,
+    tfr = fp$tfr,
+    incidence_model_choice = incidence_model_choice,
+    incidinput = incid_input,
+    transmission_rate_hts = transmission_rate_hts,
+    initial_incidence = initial_incidence,
+    epidemic_start_hts = epidemic_start_hts,
+    relative_infectiousness_art = relative_infectiousness_art,
+    incrr_age = fp$incrr_age,
+    incrr_sex = fp$incrr_sex,
+    cd4_mort = fp$cd4_mort,
+    cd4_prog = fp$cd4_prog,
+    cd4_initdist = fp$cd4_initdist,
+    scale_cd4_mort = fp$scale_cd4_mort,
+    artcd4elig_idx = fp$artcd4elig_idx,
+    art_mort = fp$art_mort,
+    artmx_timerr = fp$artmx_timerr,
+    cd4_nonaids_excess_mort = fp$cd4_nonaids_excess_mort,
+    art_nonaids_excess_mort = fp$art_nonaids_excess_mort,
+    art_dropout_recover_cd4 = fp$art_dropout_recover_cd4,
+    art_dropout_rate = -log(1.0 - fp$art_dropout / 100),
+    art15plus_num = fp$art15plus_num,
+    art15plus_isperc = fp$art15plus_isperc,
+    art_alloc_mxweight = fp$art_alloc_mxweight,
+    h_art_stage_dur = rep(0.5, fp$ss$hiv_steps_per_year - 1),
+    pAG_INCIDPOP = pAG_INCIDPOP,
+    pIDX_INCIDPOP = 15L,
+    fert_rat = fp$fert_rat,
+    cd4fert_rat = fp$cd4fert_rat,
+    frr_art6mos = fp$frr_art6mos,
+    frr_scalar = fp$frr_scalar
+  )
+
+  class(leapfrog_params) <- class(fp)
+  leapfrog_params
+}
+
+
+#' Convert leapfrog model output into eppasm mod object
+#'
+#'Note that we are not outputting a few variables at the moment. They
+# will need to be added in time.
+# * natdeaths_noart, natdeaths_art
+# * popadjust
+# * pregprevlag
+# * entrantprev
+#'
+#' @param leapfrog_result output from running leapfrog model
+#'
+#' @returns Parameters organised for running leapfog coarse age model
+#' @noRd
+leapfrog_result_to_mod <- function(leapfrog_result, leapfrog_params) {
+  # Age 0 is index 1, age 1 index 2 etc.
+  AGE_15_IDX <- 16L
+  AGE_49_IDX <- 50L
+  AGE_15TO49_IDX <- AGE_15_IDX:AGE_49_IDX
+  AGE_1580PLUS_IDX <- AGE_15_IDX:81
+
+  n_ages <- length(AGE_1580PLUS_IDX)
+  n_sex <- 2
+
+  # Populate "mod", the 3rd dimension is hiv negative, hiv +ve
+  mod <- array(0, dim = c(n_ages, n_sex, 2, leapfrog_params$sim_years))
+  hivneg_pop <- leapfrog_result$p_totpop - leapfrog_result$p_hivpop
+  mod[,,1,] <- hivneg_pop[AGE_1580PLUS_IDX,, ]
+  mod[,,2,] <- leapfrog_result$p_hivpop[AGE_1580PLUS_IDX,, ]
+  mod <- pad_last_dim(mod, leapfrog_params$proj_years)
+
+  # 15to49 prevalence
+  hivpop_15to49 <- colSums(leapfrog_result$p_hivpop[AGE_15TO49_IDX,,], dims = 2)
+  totpop_15to49 <- colSums(leapfrog_result$p_totpop[AGE_15TO49_IDX,,], dims = 2)
+  prev15to49 <- hivpop_15to49 / totpop_15to49
+
+  # 15to49 incidence is
+  # new infections in 15 - 49 / hiv -ve pop (totpop - hivpop) in previous year
+  hivneg_15to49 <- colSums(hivneg_pop[AGE_15TO49_IDX,,], dims = 2)
+  infections_15to49 <- colSums(leapfrog_result$p_infections[AGE_15TO49_IDX,,], dims = 2)
+  incid15to49 <- array(0, dim = length(hivneg_15to49))
+  n_years <- leapfrog_params$sim_years
+  incid15to49[2:n_years] <- infections_15to49[2:n_years] / hivneg_15to49[1:(n_years - 1)]
+
+  # Prevalence of HIV among pregnant women, hiv_births / births
+  pregprev <- leapfrog_result$hiv_births / leapfrog_result$births
+
+  attr(mod, "hivpop") <- leapfrog_result$h_hivpop
+  attr(mod, "artpop") <- leapfrog_result$h_artpop
+  attr(mod, "infections") <- leapfrog_result$p_infections[AGE_1580PLUS_IDX,,]
+  attr(mod, "hivdeaths") <- leapfrog_result$p_hiv_deaths[AGE_1580PLUS_IDX,,]
+  attr(mod, "natdeaths") <- leapfrog_result$p_deaths_background_hivpop[AGE_1580PLUS_IDX,,]
+  attr(mod, "excessnonaidsdeaths") <- leapfrog_result$p_deaths_excess_nonaids[AGE_1580PLUS_IDX,,]
+  attr(mod, "aidsdeaths_noart") <- leapfrog_result$h_hiv_deaths_no_art
+  attr(mod, "excessnonaidsdeaths_noart") <- leapfrog_result$h_deaths_excess_nonaids_no_art
+  attr(mod, "aidsdeaths_art") <- leapfrog_result$h_hiv_deaths_art
+  attr(mod, "excessnonaidsdeaths_art") <- leapfrog_result$h_deaths_excess_nonaids_on_art
+  attr(mod, "artinit") <- leapfrog_result$h_art_initiation
+  # For hiv time step outputs leapfrog includes for 0th year where
+  # EPPASM only starts recording this at time 1. i.e. for a 1970 to 2030
+  # projection. Leapfrog ouputs 61 (1970-2030) years for this, but
+  # EPPASM only 60 (1971-2030)
+  # Remove the first 1 year of HIV time steps to get the expected length
+  # Magic 10 for no of hiv time steps per year
+  first_year_hts <- -1:-10
+  attr(mod, "incrate15to49_ts") <- as.vector(leapfrog_result$incidence_15to49_hts)[first_year_hts]
+  attr(mod, "prev15to49_ts") <- as.vector(leapfrog_result$prevalence_15to49_hts)[first_year_hts]
+  attr(mod, "rvec_ts") <- as.vector(leapfrog_params$transmission_rate_hts)
+  attr(mod, "prev15to49") <- prev15to49
+  attr(mod, "pregprev") <- pregprev
+  attr(mod, "incid15to49") <- incid15to49
+
+  # When running with transmission input i.e. not direct incidence EPPASM
+  # will run the model for the years for which there is data and then project
+  # forward to fill in up to PROJ_YEARS. If simulation years < projection years
+  # then there will be columns of 0s
+  # We pad here with 0s to match current EPPASM behaviour
+  pad_to_proj_years <- c("hivpop", "artpop", "infections", "hivdeaths",
+                         "natdeaths", "excessnonaidsdeaths", "aidsdeaths_noart",
+                         "excessnonaidsdeaths_noart", "aidsdeaths_art",
+                         "excessnonaidsdeaths_art", "artinit", "prev15to49",
+                         "pregprev", "incid15to49")
+  pad_to_hiv_time_steps <- c("incrate15to49_ts", "prev15to49_ts")
+  for (attr_name in pad_to_proj_years) {
+    attr(mod, attr_name) <- pad_last_dim(attr(mod, attr_name), leapfrog_params$proj_years)
+  }
+  for (attr_name in pad_to_hiv_time_steps) {
+    attr(mod, attr_name) <- pad_last_dim(attr(mod, attr_name), (leapfrog_params$proj_years - 1) * 10)
+  }
+
+  class(mod) <- "spec"
+  mod
+}
+
+
+#' For a vectoror array x, pad the last dimension to expected length
+#' adding 0s.
+#'
+#' @param x Array or vector to pad
+#' @param new_length Length to achieve
+#'
+#' @returns Array or vector x padded in the last dimension to length new_length
+#' @noRd
+pad_last_dim <- function(x, new_length) {
+  is_vector <- is.vector(x)
+  is_matrix <- is.matrix(x)
+
+  if (is_vector) {
+    x <- as.array(x, dim = length(x))
+  }
+
+  dims <- dim(x)
+  from_length <- dims[length(dims)]
+
+  if (new_length <= from_length) return(x)
+
+  mat <- matrix(x, ncol = from_length)
+  pad <- matrix(0, nrow = nrow(mat), ncol = new_length - from_length)
+
+  mat2 <- cbind(mat, pad)
+
+  # reshape back to original dims
+  out <- array(mat2, dim = c(dims[-length(dims)], new_length))
+
+  if (is_vector) {
+    out <- as.vector(out)
+  } else if (is_matrix) {
+    out <- as.matrix(out)
+  }
+
+  out
+}

--- a/R/likelihood.R
+++ b/R/likelihood.R
@@ -304,7 +304,8 @@ fnCreateParam <- function(theta, fp){
 
 
   paramcurr <- epp_nparam+anclik_nparam
-  if(exists("ancrt", fp) && fp$ancrt %in% c("census", "both")){
+
+  if (exists("ancrt", fp) && fp$ancrt %in% c("census", "both")) {
     param$log_frr_adjust <- theta[paramcurr+1]
     param$frr_cd4 <- fp$frr_cd4 * exp(param$log_frr_adjust)
     param$frr_art <- fp$frr_art * exp(param$log_frr_adjust)
@@ -510,28 +511,32 @@ prepare_likdat <- function(eppd, fp){
 
   likdat$hhs.dat <- prepare_hhsageprev_likdat(eppd$hhs, fp)
 
-  if(exists("ancsitedat", where=eppd)){
+  if (exists("ancsitedat", where=eppd)) {
 
     ancsitedat <- eppd$ancsitedat
 
-    if(exists("ancrt", fp) && fp$ancrt %in% c("none", "census"))
+    if (exists("ancrt", fp) && fp$ancrt %in% c("none", "census")) {
       ancsitedat <- subset(ancsitedat, type == "ancss")
+    }
 
     likdat$ancsite.dat <- prepare_ancsite_likdat(ancsitedat, fp)
   }
 
-  if(exists("ancrtcens", where=eppd)){
-    if(exists("ancrt", fp) && fp$ancrt %in% c("none", "site"))
+  if (exists("ancrtcens", where=eppd)) {
+    if (exists("ancrt", fp) && fp$ancrt %in% c("none", "site")) {
       eppd$ancrtcens <- NULL
-    else
+    } else {
       likdat$ancrtcens.dat <- prepare_ancrtcens_likdat(eppd$ancrtcens, fp)
+    }
   }
 
-  if(exists("hhsincid", where=eppd))
+  if(exists("hhsincid", where=eppd)) {
     likdat$hhsincid.dat <- prepare_hhsincid_likdat(eppd$hhsincid, fp)
+  }
 
-  if(exists("hhsartcov", where=eppd))
+  if(exists("hhsartcov", where=eppd)) {
     likdat$hhsartcov.dat <- prepare_hhsartcov_likdat(eppd$hhsartcov, fp)
+  }
 
   return(likdat)
 }
@@ -613,9 +618,11 @@ ll <- function(theta, fp, likdat){
   theta.last <<- theta
   fp <- stats::update(fp, list=fnCreateParam(theta, fp))
 
-  if (fp$eppmod == "rspline")
-    if (any(is.na(fp$rvec)) || min(fp$rvec) < 0 || max(fp$rvec) > 20)
+  if (fp$eppmod == "rspline") {
+    if (any(is.na(fp$rvec)) || min(fp$rvec) < 0 || max(fp$rvec) > 20) {
       return(-Inf)
+    }
+  }
 
   mod <- simmod(fp)
 

--- a/R/read-spectrum-files.R
+++ b/R/read-spectrum-files.R
@@ -5,9 +5,9 @@ get_dp_version <- function(dp){
   ## * <General5>: 2015 Spectrum files
   ## * <FirstYear MV>: 2016 Spectrum file
   ## * <FirstYear MV2>: 2017+ spectrum file
-  
+
   exists_dptag <- function(tag, tagcol=1){tag %in% dp[,tagcol]}
-  
+
   dp.vers <- if (exists_dptag("<General 3>")) {
     "<General 3>"
   } else if (exists_dptag("<General5>")) {
@@ -26,7 +26,7 @@ get_dp_version <- function(dp){
 #' Read Spectrum internal files file from PJNZ
 #'
 #' @param pjnz file path to Spectrum PJNZ file.
-#' 
+#'
 #' @export
 read_dp <- function(pjnz, use_ep5 = FALSE){
 
@@ -51,7 +51,7 @@ read_pjn <- function(pjnz){
                      col_types = vroom::cols(.default = vroom::col_character()),
                      .name_repair = "minimal", progress = FALSE)
   pjn <- as.data.frame(pjn)
-  
+
   return(pjn)
 }
 
@@ -311,9 +311,9 @@ read_hivproj_output <- function(pjnz, single.age=TRUE){
     ## excess deaths by:
     ## * year (columns)
     ## * sex (slowest-changing; both, male, female),
-    ## * single age (next slowest; all, 0…80+), and 
+    ## * single age (next slowest; all, 0…80+), and
     ## * ART status (fastest-moving; off/on).
-    ## 
+    ##
     ## Align output arrays similarly to other single-age outputs: age x sex x year
     ## With 'male', and 'female', but not both sexes
 
@@ -351,7 +351,7 @@ read_hivproj_output <- function(pjnz, single.age=TRUE){
     specres$nonaids_excess_deaths_art <- array(nonaids_excess_deaths_art, lengths(dn1), dn1)
     specres$aidsdeaths_art1 <- array(aidsdeaths_art1, lengths(dn1), dn1)
     specres$aidsdeaths_noart1 <- array(aidsdeaths_noart1, lengths(dn1), dn1)
-    
+
   }
 
   specres$births <- stats::setNames(as.numeric(dpsub("<Births MV>", 2, timedat.idx)), proj.years)
@@ -373,7 +373,7 @@ read_hivproj_output <- function(pjnz, single.age=TRUE){
 ######################################################
 
 #' @export
-#' 
+#'
 read_hivproj_param <- function(pjnz, use_ep5=FALSE){
 
   ## read .DP file
@@ -524,7 +524,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
         stop("DP tag <HIVSexRatio MV> not parsed correctly")
       }
       incrr_sex <- stats::setNames(as.numeric(dpsub("<HIVSexRatio MV>", data_row, timedat.idx)), proj.years)
-      
+
     } else if (exists_dptag("<SexRatioByEpidPatt MV>")) {
       sexincrr_idx <- as.integer(dpsub("<IncEpidemicRGIdx MV>", 2, 4)) # 0-based index
       incrr_sex <- dpsub("<SexRatioByEpidPatt MV>", 3:8, timedat.idx)[sexincrr_idx+1, ]
@@ -620,7 +620,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
   ##   2) men on ART,
   ##   3) women off ART,
   ##   4) women on ART.
-  ## 
+  ##
   ## Each row is laid out left-to-right in the same as our other adult HIV-related mortality rates:
   ## * 15-24: CD4>500, 350-500, …, <50
   ## * 25-34: CD4>500, 350-500, …, <50
@@ -635,7 +635,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
     cd4_nonaids_excess_mort[,,"Male"] <- array(as.numeric(dpsub("<AdultNonAIDSExcessMort MV>", 2, 4:31)), c(DS, 4))
     art_nonaids_excess_mort[,,"Male"] <- array(as.numeric(dpsub("<AdultNonAIDSExcessMort MV>", 3, 4:31)), c(DS, 4))
     cd4_nonaids_excess_mort[,,"Female"] <- array(as.numeric(dpsub("<AdultNonAIDSExcessMort MV>", 4, 4:31)), c(DS, 4))
-    art_nonaids_excess_mort[,,"Female"] <- array(as.numeric(dpsub("<AdultNonAIDSExcessMort MV>", 5, 4:31)), c(DS, 4))    
+    art_nonaids_excess_mort[,,"Female"] <- array(as.numeric(dpsub("<AdultNonAIDSExcessMort MV>", 5, 4:31)), c(DS, 4))
   }
 
   ## program parameters
@@ -652,14 +652,14 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
   }
 
   ## # Adult on ART adjustment factor
-  ## 
+  ##
   ## * Implemented from around Spectrum 6.2 (a few versions before)
   ## * Allows user to specify scalar to reduce number on ART in each year ("<AdultARTAdjFactor>")
   ## * Enabled / disabled by checkbox flag ("<AdultARTAdjFactorFlag>")
   ## * Scaling factor only applies to number inputs, not percentages (John Stover email, 20 Feb 2023)
   ##   -> Even if scaling factor specified in a year with percentage input, ignore it.
   ##
-  ## 
+  ##
   ## ** UPDATE Spectrum 6.37 beta 18 **
   ##
   ## Two changes to the adult ART adjustment were implemented in Spectrum 6.37 beta 18:
@@ -693,7 +693,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
     if(exists_dptag("<AdultPatsAllocToFromOtherRegion>")) {
       adult_artadj_absolute <- sapply(dpsub("<AdultPatsAllocToFromOtherRegion>", 3:4, timedat.idx), as.numeric)
     }
-    
+
     ## Only apply if is number (! is percentage)
     adult_artadj_factor <- adult_artadj_factor ^ as.numeric(!art15plus_numperc)
     adult_artadj_absolute <- adult_artadj_absolute * as.numeric(!art15plus_numperc)
@@ -701,7 +701,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
     ## First add absolute adjustment, then apply scalar adjustment (Spectrum procedure)
     art15plus_num <- art15plus_num + adult_artadj_absolute
     art15plus_num <- art15plus_num * adult_artadj_factor
-  } 
+  }
 
 
   if(exists_dptag("<NewARTPatAllocationMethod MV2>"))
@@ -719,8 +719,8 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
 
   ## Replace comma decimal separator save on Francophone locale computers
   vers_str <- sub("^([0-9]+),(.*)$", "\\1.\\2", vers_str)
-  
-  version <- as.numeric(sub("^([0-9\\.]+).*", "\\1", vers_str)) 
+
+  version <- as.numeric(sub("^([0-9\\.]+).*", "\\1", vers_str))
   betav <- if(grepl("Beta", vers_str)) {
              as.numeric(sub(".*Beta ([0-9]+)$", "\\1", vers_str))
            } else {
@@ -730,7 +730,7 @@ read_hivproj_param <- function(pjnz, use_ep5=FALSE){
   if (!grepl("^[0-9]+\\.[0-9]+$", version)) {
     stop(paste0("Valid Spectrum version not recognized: ", vers_str))
   }
-  
+
   if(version >= 5.73 && (betav >= 15 | is.na(betav)))
     scale_cd4_mort <- 1L
   else
@@ -964,7 +964,7 @@ read_demog_param <- function(upd.file, age.intervals = 1){
   asfd <- array(as.numeric(pasfrs$value), c(35, nyears))
   dimnames(asfd) <- list(age=15:49, year=years)
   asfd <- sweep(asfd, 2, colSums(asfd), "/")
-  
+
   asfr <- sweep(asfd, 2, tfr, "*")
   asfr <- apply(asfr, 2, tapply, age.groups[16:50], mean)
 
@@ -1038,11 +1038,11 @@ read_specdp_demog_param <- function(pjnz, use_ep5=FALSE){
   ## mx
   if(dp.vers == "Spectrum2016"){
     sx.tidx <- which(dp[,1] == "<SurvRate MV>")
-    Sx <- dp[sx.tidx+3+c(0:79,81, 83+0:79, 83+81), timedat.idx]
+    Sx <- dp[sx.tidx+3+c(0:81, 83+0:81), timedat.idx]
   } else if(dp.vers == "Spectrum2017")
-    Sx <- dpsub("<SurvRate MV2>", 3+c(0:79, 81, 82+0:79, 82+81), timedat.idx)
-  Sx <- array(as.numeric(unlist(Sx)), c(81, 2, length(proj.years)))
-  dimnames(Sx) <- list(age=0:80, sex=c("Male", "Female"), year=proj.years)
+    Sx <- dpsub("<SurvRate MV2>", 3+c(0:81, 82+0:81), timedat.idx)
+  Sx <- array(as.numeric(unlist(Sx)), c(82, 2, length(proj.years)))
+  dimnames(Sx) <- list(age=c(0:80, "80+"), sex=c("Male", "Female"), year=proj.years)
 
   mx <- -log(Sx)
 
@@ -1058,7 +1058,7 @@ read_specdp_demog_param <- function(pjnz, use_ep5=FALSE){
   asfd_sum <- colSums(asfd)
   asfd_sum[asfd_sum == 0.0] <- 1.0
   asfd <- sweep(asfd, 2, asfd_sum, "/")
-  
+
   dimnames(asfd) <- list(age=15:49, year=proj.years)
   asfr <- sweep(asfd, 2, tfr, "*")
 
@@ -1138,9 +1138,9 @@ read_specdp_demog_param <- function(pjnz, use_ep5=FALSE){
   u5prop[3, ] <- Sx[3, , 1] * u5prop[2, ]
   u5prop[4, ] <- Sx[4, , 1] * u5prop[3, ]
   u5prop[5, ] <- Sx[5, , 1] * u5prop[4, ]
-  
+
   u5prop <- sweep(u5prop, 2, colSums(u5prop), "/")
-  
+
   netmigr[1:5 , 1, ] <- u5prop[ , 1, drop = FALSE] %*% netmigr5[1, 1, ]
   netmigr[1:5 , 2, ] <- u5prop[ , 2, drop = FALSE] %*% netmigr5[1, 2, ]
 
@@ -1198,7 +1198,7 @@ read_epp_t0 <- function(pjnz){
 
   obj <- xml2::xml_find_all(r, ".//object")
   projsets <- obj[which(xml2::xml_attr(obj, "class") == "epp2011.core.sets.ProjectionSet")]
-  
+
   t0 <- list()
   for(nd in projsets) {
     ns <- xml2::xml_children(nd)

--- a/R/rt-models.R
+++ b/R/rt-models.R
@@ -12,7 +12,7 @@ prepare_logrw <- function(fp, tsEpidemicStart=fp$ss$time_epi_start+0.5){
     rt$n_rw <- fp$n_rw
 
   fp$numKnots <- rt$n_rw
-  
+
   ## Random walk design matrix
   rt$rw_knots <- seq(min(rw_steps), max(rw_steps), length.out=rt$n_rw+1)
   rt$rwX <- outer(rw_steps, rt$rw_knots[1:rt$n_rw], ">=")
@@ -21,18 +21,18 @@ prepare_logrw <- function(fp, tsEpidemicStart=fp$ss$time_epi_start+0.5){
   fp$rt <- rt
 
   fp$rvec.spldes <- rbind(matrix(0, rt$nsteps_preepi, fp$numKnots), rt$rwX)
-                                
+
   if(!exists("eppmod", fp))
     fp$eppmod <- "logrw"
   fp$iota <- NULL
-  
+
   return(fp)
 }
 
 
 rlog_pr_mean <- c(log(0.35), log(0.09), log(0.2), 1993)
 rlog_pr_sd <- c(0.5, 0.3, 0.5, 5)
-                
+
 rlogistic <- function(t, p){
   ## p[1] = log r(0)    : log r(t) at the start of the epidemic (exponential growth)
   ## p[2] = log r(Inf)  : endemic value for log r(t)
@@ -44,7 +44,7 @@ rlogistic <- function(t, p){
 
 
 #' Setup the r-hybrid model
-#' 
+#'
 #' @param fp model parameters object
 #' @param tsEpidemicStart time step at which epidemic is seeded
 #' @param rw_start time when random walk starts
@@ -71,25 +71,25 @@ prepare_rhybrid <- function(fp,
   rt <- list()
 
   rt$proj.steps <- fp$proj.steps
-  
+
   rt$rw_start <- rw_start
   rt$rw_trans <- rw_trans
 
   switch_idx <- max(which(fp$proj.steps <= rw_start))
   rt$rlogistic_steps <- fp$proj.steps[1:switch_idx]
   rt$rw_steps <- fp$proj.steps[switch_idx:length(fp$proj.steps)]
-  
+
   rt$n_rw <- ceiling((max(rt$proj.steps) - rw_start) / rw_dk)
   rt$rw_dk <- rw_dk
   rt$rw_knots <- seq(rw_start, rw_start + rt$rw_dk * rt$n_rw, by = rt$rw_dk)
   rt$rw_idx <- findInterval(rt$rw_steps[-1], rt$rw_knots)
-  
+
   rt$n_param <- 4+rt$n_rw  # 4 parameters for rlogistic
 
   ## Linearly interpolate between 0 and 1 over the period (rw_start, rw_start + rw_trans)
   ## Add a small value to avoid R error in approx() if rw_trans = 0
   rt$rw_transition <- stats::approx(c(rw_start, rw_start + rw_trans + 0.001), c(0, 1), rt$rw_steps[-1], rule = 2)$y
-  
+
   rt$dt <- 1 / fp$ss$hiv_steps_per_year
 
   rt$eppmod <- "rhybrid"
@@ -98,7 +98,7 @@ prepare_rhybrid <- function(fp,
   if(!exists("eppmod", fp))
     fp$eppmod <- "rhybrid"
   fp$iota <- NULL
-  
+
   return(fp)
 }
 
@@ -138,7 +138,7 @@ extend_projection <- function(fit, proj_years){
 
   if(proj_years > fit$fp$ss$PROJ_YEARS)
     stop("Cannot extend projection beyond duration of projection file")
-  
+
   fp <- fit$fp
   fpnew <- fp
 
@@ -161,7 +161,7 @@ extend_projection <- function(fit, proj_years){
      fit$rw_sigma <- fp$prior_args$rw_prior_sd
   else
     fit$rw_sigma <- rw_prior_sd
-  
+
   nsteps <- fpnew$rt$n_rw - fp$rt$n_rw
 
   if(nsteps > 0){
@@ -200,7 +200,7 @@ calc_rtrend_rt <- function(t, fp, rveclast, prevlast, pop, i, ii){
 
   prevcurr <- hivp.ii / (hivn.ii + hivp.ii)
 
-  
+
   if(t > fp$tsEpidemicStart){
     par <- fp$rtrend
     gamma.t <- if(t < par$tStabilize) 0 else (prevcurr-prevlast)*(t - par$tStabilize) / (fp$ss$DT*prevlast)
@@ -233,7 +233,7 @@ transf_iota <- function(par, fp){
   if(exists("logitiota", fp) && fp$logitiota)
     exp(invlogit(par)*diff(logiota.unif.prior) + logiota.unif.prior[1])
   else
-    exp(par)  
+    exp(par)
 }
 
 lprior_iota <- function(par, fp){

--- a/R/spectrum.R
+++ b/R/spectrum.R
@@ -4,7 +4,7 @@
 #' If argument `projection_period = NULL`, R determines the projection period based
 #' on the Spectrum version number. For version <= 6.19, projection period is `"midyear"`,
 #' and for version >= 6.20, projection period is `"calendar"`.
-#' 
+#'
 
 #' @export
 create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_start = projp$yr_start, proj_end = projp$yr_end,
@@ -13,7 +13,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
                                    frr_art6mos=projp$frr_art6mos, frr_art1yr=projp$frr_art6mos,
                                    projection_period = NULL,
                                    art_dropout_recover_cd4 = NULL) {
-  
+
   ## ########################## ##
   ##  Define model state space  ##
   ## ########################## ##
@@ -24,7 +24,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
              AGE_START  = as.integer(AGE_START),
              hiv_steps_per_year = as.integer(hiv_steps_per_year),
              time_epi_start=time_epi_start)
-             
+
   ## populuation projection state-space
   ss$NG <- 2
   ss$pDS <- 2               # Disease stratification for population projection (HIV-, and HIV+)
@@ -42,7 +42,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   ss$p.age15to49.idx <- 16:50 - AGE_START
   ss$p.age15plus.idx <- (16-AGE_START):ss$pAG
 
-  
+
   ## HIV model state-space
   ss$h.ag.span <- as.integer(c(2,3, rep(5, 6), 31))   # Number of population age groups spanned by each HIV age group [sum(h.ag.span) = pAG]
   ss$hAG <- length(ss$h.ag.span)          # Number of age groups
@@ -66,20 +66,20 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   fp$SIM_YEARS <- ss$PROJ_YEARS
   fp$proj.steps <- proj_start + 0.5 + 0:(ss$hiv_steps_per_year * (fp$SIM_YEARS-1)) / ss$hiv_steps_per_year
 
-  
+
   if (is.null(projection_period)) {
-    
+
     if (!grepl("^[4-6]\\.[0-9]", projp$spectrum_version)) {
       stop(paste0("Spectrum version not recognized: ", projp$spectrum_version))
     }
     fp$projection_period <- if (projp$spectrum_version >= "6.2") {"calendar"} else {"midyear"}
-    
+
   } else {
     stopifnot(projection_period %in% c("calendar", "midyear"))
     fp$projection_period <- projection_period
   }
 
-  
+
   ## ######################## ##
   ##  Demographic parameters  ##
   ## ######################## ##
@@ -90,29 +90,34 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   bp_dist <- 1-(proj_start - bp_years[bp_aidx]) / diff(bp_years[bp_aidx+0:1])
   basepop_allage <- rowSums(sweep(demp$basepop[,, bp_aidx+0:1], 3, c(bp_dist, 1-bp_dist), "*"),,2)
 
+  fp$basepop_allage <- basepop_allage
   fp$basepop <- basepop_allage[(AGE_START+1):81,]
-  fp$Sx <- demp$Sx[(AGE_START+1):81,,as.character(proj_start:proj_end)]
 
+  fp$Sx_allage <- demp$Sx[,,as.character(proj_start:proj_end)]
+  fp$Sx <- demp$Sx[c((AGE_START+1):80, 82),,as.character(proj_start:proj_end)]
+
+  fp$tfr <- demp$tfr
   fp$asfr <- demp$asfr[,as.character(proj_start:proj_end)] # NOTE: assumes 15-49 is within projection age range
   ## Note: Spectrum averages ASFRs from the UPD file over 5-year age groups.
   ##       Prefer to use single-year of age ASFRs as provided. The below line will
   ##       convert to 5-year average ASFRs to exactly match Spectrum.
   ## fp$asfr <- apply(apply(fp$asfr, 2, tapply, rep(3:9*5, each=5), mean), 2, rep, each=5)
-  
+
   fp$srb <- sapply(demp$srb[as.character(proj_start:proj_end)], function(x) c(x,100)/(x+100))
-  
+
   netmigr.adj <- demp$netmigr
 
   if (fp$projection_period == "midyear") {
 
     ## Spectrum mid-year projection (v5.19 and earlier) adjusts net-migration to occur
     ## half in current age group and half in next age group
-    
+
     netmigr.adj[-1,,] <- (demp$netmigr[-1,,] + demp$netmigr[-81,,])/2
     netmigr.adj[1,,] <- demp$netmigr[1,,]/2
     netmigr.adj[81,,] <- netmigr.adj[81,,] + demp$netmigr[81,,]/2
   }
 
+  fp$netmigr_adj <- netmigr.adj
   fp$netmigr <- netmigr.adj[(AGE_START+1):81,,as.character(proj_start:proj_end)]
 
 
@@ -121,7 +126,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   ## For cohorts born before projection start, this will be the partial
   ## survival since the projection start to AGE_START, and the corresponding lagged "births"
   ## represent the number in the basepop who will survive to the corresponding age.
-  
+
   cumnetmigr <- array(0, dim=c(NG, PROJ_YEARS))
   cumsurv <- array(1, dim=c(NG, PROJ_YEARS))
   if(AGE_START > 0)
@@ -139,11 +144,11 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
             cumnetmigr[s,i] <- cumnetmigr[s,i]*demp$Sx[j,s,ii] + netmigr.adj[j,s,ii]
           }
         }
-  
+
   ## initial values for births
   birthslag <- array(0, dim=c(NG, PROJ_YEARS))             # birthslag(i,s) = number of births of sex s, i-AGE_START years ago
   birthslag[,1:AGE_START] <- t(basepop_allage[AGE_START:1,])  # initial pop values (NOTE REVERSE ORDER). Rest will be completed by fertility during projection
-  
+
   fp$birthslag <- birthslag
   fp$cumsurv <- cumsurv
   fp$cumnetmigr <- cumnetmigr
@@ -158,7 +163,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   if(popadjust & is.null(fp$targetpop))
     stop("targetpop does not span proj_start:proj_end")
 
-  
+
   ## ###################### ##
   ##  HIV model parameters  ##
   ## ###################### ##
@@ -166,13 +171,13 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   fp$relinfectART <- projp$relinfectART
 
   fp$incrr_sex <- projp$incrr_sex[as.character(proj_start:proj_end)]
-  
+
   ## Use Beer's coefficients to distribution IRRs by age/sex
   Amat <- create_beers(17)
   fp$incrr_age <- apply(projp$incrr_age, 2:3, function(x)  Amat %*% x)[AGE_START + 1:pAG, , as.character(proj_start:proj_end)]
   fp$incrr_age[fp$incrr_age < 0] <- 0
-  
-  
+
+
   projp.h.ag <- findInterval(AGE_START + cumsum(h.ag.span) - h.ag.span, c(15, 25, 35, 45))  # NOTE: Will not handle AGE_START < 15 presently
   fp$cd4_initdist <- projp$cd4_initdist[,projp.h.ag,]
   fp$cd4_prog <- (1-exp(-projp$cd4_prog[,projp.h.ag,] / hiv_steps_per_year)) * hiv_steps_per_year
@@ -188,11 +193,17 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   frr_agecat[frr_agecat == 18] <- 17
   fert_rat.h.ag <- findInterval(AGE_START + cumsum(h.ag.span[h.fert.idx]) - h.ag.span[h.fert.idx], frr_agecat)
 
+  fp$fert_rat <- array(1, c(length(h.fert.idx), PROJ_YEARS))
+  fp$fert_rat <- rep(projp$fert_rat[fert_rat.h.ag, as.character(floor(proj_end):proj_start)], length(PROJ_YEARS))
+  fp$cd4fert_rat <- projp$cd4fert_rat
+  fp$frr_art6mos <- array(projp$frr_art6mos[fert_rat.h.ag])
+  fp$frr_scalar <- as.numeric(projp$frr_scalar)
+
   fp$frr_cd4 <- array(1, c(hDS, length(h.fert.idx), PROJ_YEARS))
   fp$frr_cd4[,,] <- rep(projp$fert_rat[fert_rat.h.ag, as.character(proj_start:proj_end)], each=hDS)
   fp$frr_cd4 <- sweep(fp$frr_cd4, 1, projp$cd4fert_rat, "*")
   fp$frr_cd4 <- fp$frr_cd4 * projp$frr_scalar
-  
+
   fp$frr_art <- array(1.0, c(hTS, hDS, length(h.fert.idx), PROJ_YEARS))
   fp$frr_art[1,,,] <- fp$frr_cd4 # 0-6 months
   fp$frr_art[2:hTS, , , ] <- sweep(fp$frr_art[2:hTS, , , ], 3, projp$frr_art6mos[fert_rat.h.ag] * projp$frr_scalar, "*") # 6-12mos, >1 years
@@ -219,7 +230,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
   ## percentage of those with CD4 <350 who are based on WHO Stage III/IV infection
   fp$who34percelig <- who34percelig
 
-  if (is.null(art_dropout_recover_cd4)) { 
+  if (is.null(art_dropout_recover_cd4)) {
     fp$art_dropout_recover_cd4 <- if (projp$spectrum_version >= "6.14") {TRUE} else {FALSE}
   } else {
     fp$art_dropout_recover_cd4 <- art_dropout_recover_cd4
@@ -227,7 +238,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
 
   ## Convert input percent dropout in 12 months to an annual rate (Rob Glaubius email 25 July 2024)
   fp$art_dropout <- -log(1.0 - projp$art_dropout[as.character(proj_start:proj_end)]/100)
-  
+
   fp$median_cd4init <- projp$median_cd4init[as.character(proj_start:proj_end)]
   fp$med_cd4init_input <- as.integer(fp$median_cd4init > 0)
   fp$med_cd4init_cat <- replace(findInterval(-fp$median_cd4init, - c(1000, 500, 350, 250, 200, 100, 50)),
@@ -241,9 +252,9 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
 
   ## Scale mortality among untreated population by ART coverage
   fp$scale_cd4_mort <- projp$scale_cd4_mort
-  
+
   ## Vertical transmission and survival to AGE_START for lagged births
-  
+
   fp$verttrans_lag <- stats::setNames(c(rep(0, AGE_START), projp$verttrans[1:(PROJ_YEARS-AGE_START)]), proj_start:proj_end)
 
   ## calculate probability of HIV death in each year
@@ -274,7 +285,7 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
 
   hiv_noart14 <- hivpop15[1,,,]
   artpop14 <- hivpop15[2:4,,,]
-  
+
   fp$paedsurv_cd4dist <- array(0, c(hDS, NG, PROJ_YEARS))
   fp$paedsurv_artcd4dist <- array(0, c(hTS, hDS, NG, PROJ_YEARS))
 
@@ -292,18 +303,18 @@ create_spectrum_fixpar <- function(projp, demp, hiv_steps_per_year = 10L, proj_s
       fp$paedsurv_artcd4dist[ , idx, , i] <- fp$paedsurv_artcd4dist[ , idx, , i] +
         c(apply(fp$paedsurv_artcd4dist[ , 1:(idx-1), , i, drop=FALSE], c(1,3,4), sum))
       fp$paedsurv_artcd4dist[,1:(idx-1),,i] <- 0
-    } 
+    }
   }
-  
+
   fp$netmig_hivprob <- 0.4*0.22
   fp$netmighivsurv <- 0.25/0.22
-  
+
   ## Circumcision parameters (default no effect)
   fp$circ_incid_rr <- 0.0  # no reduction
   fp$circ_prop <- array(0.0, c(ss$pAG, ss$PROJ_YEARS),
                         list(age = ss$AGE_START + 1:ss$pAG - 1L,
                              year = ss$proj_start + 1:ss$PROJ_YEARS - 1L))
-  
+
   class(fp) <- "specfp"
 
   return(fp)
@@ -320,8 +331,9 @@ prepare_rtrend_model <- function(fp, iota=0.0025) {
 
 prepare_rspline_model <- function(fp, numKnots=NULL, tsEpidemicStart=fp$ss$time_epi_start+0.5) {
 
-  if(!exists("numKnots", fp))
+  if(!exists("numKnots", fp)) {
     fp$numKnots <- 7
+  }
 
   fp$tsEpidemicStart <- fp$proj.steps[which.min(abs(fp$proj.steps - tsEpidemicStart))]
   epi_steps <- fp$proj.steps[fp$proj.steps >= fp$tsEpidemicStart]
@@ -340,23 +352,23 @@ prepare_rspline_model <- function(fp, numKnots=NULL, tsEpidemicStart=fp$ss$time_
 }
 
 
-#' @export 
+#' @export
 update.specfp <- function (object, ..., keep.attr = TRUE, list = vector("list")) {
   dots <- substitute(list(...))[-1]
   newnames <- names(dots)
   for (j in seq_along(dots)) {
-    if (keep.attr) 
+    if (keep.attr)
       attr <- attributes(object[[newnames[j]]])
     object[[newnames[j]]] <- eval(dots[[j]], object, parent.frame())
-    if (keep.attr) 
+    if (keep.attr)
       attributes(object[[newnames[j]]]) <- c(attr, attributes(object[[newnames[j]]]))
   }
   listnames <- names(list)
   for (j in seq_along(list)) {
-        if (keep.attr) 
+        if (keep.attr)
           attr <- attributes(object[[listnames[j]]])
         object[[listnames[j]]] <- eval(list[[j]], object, parent.frame())
-        if (keep.attr) 
+        if (keep.attr)
           attributes(object[[listnames[j]]]) <- c(attr, attributes(object[[listnames[j]]]))
   }
   return(object)
@@ -369,26 +381,26 @@ update.specfp <- function (object, ..., keep.attr = TRUE, list = vector("list"))
 
 ## modprev15to49 <- function(mod, fp){colSums(mod[fp$ss$p.age15to49.idx,,fp$ss$hivp.idx,],,2) / colSums(mod[fp$ss$p.age15to49.idx,,,],,3)}
 
-#' @export 
+#' @export
 prev.spec <- function(mod, fp, ...){ attr(mod, "prev15to49") }
 
-#' @export 
+#' @export
 incid.spec <- function(mod, fp, ...){ attr(mod, "incid15to49") }
 
-#' @export 
+#' @export
 fnPregPrev.spec <- function(mod, fp, ...) { attr(mod, "pregprev") }
 
-#' @export 
+#' @export
 calc_prev15to49 <- function(mod, fp){
   colSums(mod[fp$ss$p.age15to49.idx,,2,],,2)/colSums(mod[fp$ss$p.age15to49.idx,,,],,3)
 }
 
-#' @export 
+#' @export
 calc_incid15to49 <- function(mod, fp){
   c(0, colSums(attr(mod, "infections")[fp$ss$p.age15to49.idx,,-1],,2)/colSums(mod[fp$ss$p.age15to49.idx,,1,-fp$ss$PROJ_YEARS],,2))
 }
 
-#' @export 
+#' @export
 calc_pregprev <- function(mod, fp){
   warning("not yet implemented")
 }
@@ -409,7 +421,7 @@ calc_pregprev <- function(mod, fp){
 #' @param mod output of simmod of class \code{\link{spec}}.
 #' @return 3-dimensional array of mortality by age, sex, and year.
 #'
-#' @export 
+#' @export
 agemx.spec <- function(mod, nonhiv=FALSE) {
   if(nonhiv)
     deaths <- attr(mod, "natdeaths")
@@ -438,7 +450,7 @@ agemx.spec <- function(mod, nonhiv=FALSE) {
 #' @param mod output of simmod of class \code{\link{spec}}.
 #' @return 3-dimensional array of mortality by age, sex, and year.
 #'
-#' @export 
+#' @export
 natagemx.spec <- function(mod) {
   deaths <- attr(mod, "natdeaths")
   pop <- mod[,,1,]+ mod[,,2,]
@@ -466,15 +478,15 @@ hivagemx.spec <- function(mod) {
 #' @param sidx sex (1 = Male, 2 = Female, 0 = Both)
 #' Notes: Assumes that AGE_START is 15 and single year of age.
 #'
-#' 
+#'
 #' @useDynLib eppasm ageprevC
 #' @export
-#' 
+#'
 ageprev <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, expand=FALSE, VERSION="C") {
 
   if(length(agspan)==1)
     agspan <- rep(agspan, length(aidx))
-  
+
   if(expand) {
     dimout <- c(length(aidx), length(sidx), length(yidx))
     df <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
@@ -482,37 +494,37 @@ ageprev <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, expand=FALSE
     sidx <- df$sidx
     yidx <- df$yidx
     agspan <- rep(agspan, times=length(sidx)*length(yidx))
-  } 
-  
-  if(VERSION != "R") { 
+  }
+
+  if(VERSION != "R") {
 
     prev <- .Call(ageprevC, mod,
                   as.integer(aidx), as.integer(sidx),
                   as.integer(yidx), as.integer(agspan))
-    
+
   } else {
 
     idx <- data.frame(aidx=aidx, sidx=sidx, yidx=yidx, agspan=agspan)
     idx$gidx <- seq_len(nrow(idx))
-    
+
     ## Add M/F entries with same id if sidx = 0.
     ## This is probably a pretty inefficient way of doing this...
-    
+
     if(any(idx$sidx == 0)) {
       idx <- rbind(idx[idx$sidx != 0,], transform(idx[idx$sidx == 0,], sidx = 1), transform(idx[idx$sidx == 0,], sidx = 2))
       idx <- idx[order(idx$gidx, idx$sidx),]
     }
-    
+
     idx$id <- seq_len(nrow(idx))
-    
+
     increment <- unlist(lapply(idx$agspan, seq_len))-1
     id_idx <- rep(idx$id, idx$agspan)
-    
+
     g_idx <- idx$gidx[id_idx]
     a_idx <- idx$aidx[id_idx] + increment
     s_idx <- idx$sidx[id_idx]
     y_idx <- idx$yidx[id_idx]
-    
+
     hivn <- fastmatch::ctapply(mod[cbind(a_idx, s_idx, 1, y_idx)], g_idx, sum)
     hivp <- fastmatch::ctapply(mod[cbind(a_idx, s_idx, 2, y_idx)], g_idx, sum)
     prev <- hivp/(hivn+hivp)
@@ -521,7 +533,7 @@ ageprev <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, expand=FALSE
 
   if(expand)
     prev <- array(prev, dimout)
-    
+
   return(prev)
 }
 
@@ -530,7 +542,7 @@ ageincid <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NULL
   if(is.null(arridx)) {
     if(length(agspan)==1)
       agspan <- rep(agspan, length(aidx))
-    
+
     dims <- dim(mod)
     idx <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
     arridx_inf <- idx$aidx + (idx$sidx-1)*dims[1] + (idx$yidx-1)*dims[1]*dims[2]
@@ -548,7 +560,7 @@ ageincid <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NULL
 
   inf <- fastmatch::ctapply(attr(mod, "infections")[allidx_inf], agidx_inf, sum)
   hivn <- fastmatch::ctapply(mod[,,1,][allidx_hivn], agidx_hivn, sum)
-  
+
   incid <- inf/hivn
   if(!is.null(aidx))
     incid <- array(incid, c(length(aidx), length(sidx), length(yidx)))
@@ -561,7 +573,7 @@ ageinfections <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx
   if(is.null(arridx)) {
     if(length(agspan)==1)
       agspan <- rep(agspan, length(aidx))
-    
+
     dims <- dim(mod)
     idx <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
     arridx_inf <- idx$aidx + (idx$sidx-1)*dims[1] + (idx$yidx-1)*dims[1]*dims[2]
@@ -576,7 +588,7 @@ ageinfections <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx
   allidx_inf <- agidx_inf + unlist(sapply(agspan, seq_len))-1
 
   inf <- fastmatch::ctapply(attr(mod, "infections")[allidx_inf], agidx_inf, sum)
-  
+
   if(!is.null(aidx))
     inf <- array(inf, c(length(aidx), length(sidx), length(yidx)))
   return(inf)
@@ -584,11 +596,11 @@ ageinfections <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx
 
 ageartcov <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NULL,
                       h.ag.span=c(2, 3, 5, 5, 5, 5, 5, 5, 31)) {
-  
+
   if(is.null(arridx)) {
     if(length(agspan)==1)
       agspan <- rep(agspan, length(aidx))
-    
+
     dims <- dim(mod)
     idx <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
     arridx <- idx$aidx + (idx$sidx-1)*dims[1] + (idx$yidx-1)*dims[1]*dims[2]
@@ -598,7 +610,7 @@ ageartcov <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NUL
     if(length(agspan)==1)
       agspan <- rep(agspan, length(arridx))
   }
-  
+
   agidx <- rep(arridx, agspan)
   sidx.ag <- rep(idx$sidx, agspan)
   yidx.ag <- rep(idx$yidx, agspan)
@@ -616,7 +628,7 @@ ageartcov <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NUL
 
   artp <- fastmatch::ctapply(mod[,,2,][allidx]*artcov[hallidx], agidx, sum) # number on ART
   hivp <- fastmatch::ctapply(mod[,,2,][allidx], agidx, sum)
-  
+
   artcov <- artp/hivp
   if(!is.null(aidx))
     artcov <- array(artcov, c(length(aidx), length(sidx), length(yidx)))
@@ -625,7 +637,7 @@ ageartcov <- function(mod, aidx=NULL, sidx=NULL, yidx=NULL, agspan=5, arridx=NUL
 
 
 #' Age-specific prevalence among pregnant women
-#' 
+#'
 #' @param expand whether to expand aidx, yidx, sidx, and agspan
 #'
 #' @export
@@ -638,7 +650,7 @@ agepregprev <- function(mod, fp,
 
   if(length(agspan)==1)
     agspan <- rep(agspan, length(aidx))
-  
+
   if(expand) {
     idx <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
     idx$agspan <- rep(agspan, times=length(sidx)*length(yidx))
@@ -665,7 +677,7 @@ agepregprev <- function(mod, fp,
   hivpop_fert <- attr(mod, "hivpop")[ , fp$ss$h.fert.idx, fp$ss$f.idx, ]
   artpop_fert <- attr(mod, "artpop")[ , , fp$ss$h.fert.idx, fp$ss$f.idx, ]
   ha_frr <- (colSums(hivpop_fert * fp$frr_cd4) + colSums(artpop_fert * fp$frr_art,,2)) / (colSums(hivpop_fert) + colSums(artpop_fert,,2))
-  
+
   births_a <- fp$asfr[cbind(fert_idx, y_idx)] * (hivn + hivp)
   pregprev_a <- 1 - hivn / (hivn + ha_frr[cbind(hfert_idx, y_idx)] * hivp)
 
@@ -675,7 +687,7 @@ agepregprev <- function(mod, fp,
 
 
 #' Age-specific ART coverage among pregnant women
-#' 
+#'
 #' @param expand whether to expand aidx, yidx, sidx, and agspan
 #'
 #' @export
@@ -685,33 +697,33 @@ agepregartcov <- function(mod, fp,
                           agspan=5,
                           expand=FALSE) {
   sidx <- fp$ss$f.idx # only women get pregnant
-  
+
   if(length(agspan)==1)
     agspan <- rep(agspan, length(aidx))
-  
+
   if(expand) {
     idx <- expand.grid(aidx=aidx, sidx=sidx, yidx=yidx)
     idx$agspan <- rep(agspan, times=length(sidx)*length(yidx))
   } else {
     idx <- data.frame(aidx=aidx, sidx=sidx, yidx=yidx, agspan=agspan)
   }
-  
+
   idx$id <- seq_len(nrow(idx))
-  
+
   increment <- unlist(lapply(idx$agspan, seq_len))-1
   a_idx <- rep(idx$aidx, idx$agspan) + increment
   s_idx <- rep(idx$sidx, idx$agspan)
   y_idx <- rep(idx$yidx, idx$agspan)
   yminus1_idx <- rep(pmax(idx$yidx-1, 1), idx$agspan)
   id_idx <- rep(idx$id, idx$agspan)
-  
+
   ## get index in asfr and ha_frr array
   fert_idx <- match(a_idx, fp$ss$p.fert.idx)
   hfert_idx <- match(fp$ss$ag.idx[a_idx], fp$ss$h.fert.idx)
-  
+
   hivp <- (mod[cbind(a_idx, s_idx, 2, y_idx)] + mod[cbind(a_idx, s_idx, 2, yminus1_idx)]) / 2
   hivn <- (mod[cbind(a_idx, s_idx, 1, y_idx)] + mod[cbind(a_idx, s_idx, 1, yminus1_idx)]) / 2
-  
+
   ## Calculate age-specific FRR given the CD4 and ART duration distribution
   hivpop_fert <- attr(mod, "hivpop")[ , fp$ss$h.fert.idx, fp$ss$f.idx, ]
   artpop_fert <- attr(mod, "artpop")[ , , fp$ss$h.fert.idx, fp$ss$f.idx, ]
@@ -724,7 +736,7 @@ agepregartcov <- function(mod, fp,
   births_a <- fp$asfr[cbind(fert_idx, y_idx)] * (hivn + hivp)
   pregprev_a <- 1 - hivn / (hivn + ha_frr[cbind(hfert_idx, y_idx)] * hivp)
   artcov_a <- ha_artcov[cbind(hfert_idx, y_idx)]
-  
+
   fastmatch::ctapply(artcov_a * pregprev_a * births_a, id_idx, sum) / fastmatch::ctapply(pregprev_a * births_a, id_idx, sum)
 }
 
@@ -746,14 +758,14 @@ pop15to49.spec <- function(mod){colSums(mod[1:35,,,],,3)}
 artpop15to49.spec <- function(mod){colSums(attr(mod, "artpop")[,,1:8,,],,4)}
 artpop15plus.spec <- function(mod){colSums(attr(mod, "artpop"),,4)}
 
-#' @export 
+#' @export
 artcov15to49.spec <- function(mod, sex=1:2, ...) {
   n_art <- colSums(attr(mod, "artpop")[,,1:8,sex,,drop=FALSE],,4)
   n_hiv <- colSums(attr(mod, "hivpop")[,1:8,sex,,drop=FALSE],,3)
   return(n_art / (n_hiv+n_art))
 }
 
-#' @export 
+#' @export
 artcov15plus.spec <- function(mod, sex=1:2, ...) {
   n_art <- colSums(attr(mod, "artpop")[,,,sex,,drop=FALSE],,4)
   n_hiv <- colSums(attr(mod, "hivpop")[,,sex,,drop=FALSE],,3)

--- a/eppasm.Rproj
+++ b/eppasm.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/imis.Rd
+++ b/man/imis.Rd
@@ -12,10 +12,10 @@ imis(
   opt_k = NULL,
   fp,
   likdat,
-  prior = eppasm::prior,
-  likelihood = eppasm::likelihood,
-  sample_prior = eppasm::sample.prior,
-  dsamp = eppasm::dsamp,
+  prior = eppasm:::prior,
+  likelihood = eppasm:::likelihood,
+  sample_prior = eppasm:::sample.prior,
+  dsamp = eppasm:::dsamp,
   save_all = FALSE
 )
 }

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -50,7 +50,7 @@
 #define INCIDPOP_15TO49 0 // age range corresponding to incidence input
 #define INCIDPOP_15PLUS 1
 
-#define PROJPERIOD_MIDYEAR 0   // mid-year projection period 
+#define PROJPERIOD_MIDYEAR 0   // mid-year projection period
 #define PROJPERIOD_CALENDAR 1  // calendar-year projection (Spectrum 6.2 update; December 2022)
 
 
@@ -176,7 +176,7 @@ extern "C" {
       a_relbehav_age = REAL(getListElement(s_fp, "relbehav_age"));
     }
     multi_array_ref<double, 2> relbehav_age(a_relbehav_age, extents[NG][pAG]);
-    
+
     multi_array_ref<double, 3> incrr_age(REAL(getListElement(s_fp, "incrr_age")), extents[PROJ_YEARS][NG][pAG]);
 
     int eppmod = *INTEGER(getListElement(s_fp, "eppmodInt"));
@@ -198,7 +198,7 @@ extern "C" {
       relinfectART = *REAL(getListElement(s_fp, "relinfectART"));
       tsEpidemicStart = *REAL(getListElement(s_fp, "tsEpidemicStart"));
       iota = *REAL(getListElement(s_fp, "iota"));
-      
+
       if(eppmod == EPP_RSPLINE)
 	rspline_rvec = REAL(getListElement(s_fp, "rvec"));
       else if(eppmod == EPP_RTREND){
@@ -303,7 +303,7 @@ extern "C" {
     Rf_setAttrib(s_pop, Rf_install("excessnonaidsdeaths"), s_excessnonaidsdeaths);
     multi_array_ref<double, 3> excessnonaidsdeaths(REAL(s_excessnonaidsdeaths), extents[PROJ_YEARS][NG][pAG]);
     memset(REAL(s_excessnonaidsdeaths), 0, Rf_length(s_excessnonaidsdeaths)*sizeof(double));
-    
+
     SEXP s_aidsdeaths_noart = PROTECT(Rf_allocVector(REALSXP, hDS * hAG * NG * PROJ_YEARS));
     SEXP s_aidsdeaths_noart_dim = PROTECT(Rf_allocVector(INTSXP, 4));
     INTEGER(s_aidsdeaths_noart_dim)[0] = hDS;
@@ -522,7 +522,7 @@ extern "C" {
 
         double paedsurv_g;
         double entrant_prev;
-	
+
 	if(use_entrantprev)
 	  entrant_prev = entrantprev[t][g];
 	else
@@ -630,7 +630,7 @@ extern "C" {
 
       if (eppmod == EPP_DIRECTINCID_ANN ||
 	  eppmod == EPP_DIRECTINCID_HTS ) {
-	
+
 	// Calculate incidence rate by sex
 	// (Note: incidence rate by age is calculated per time-step using the
 	//    **current year** HIV population, instead of the previous year
@@ -648,7 +648,7 @@ extern "C" {
 	incrate_g[MALE] = incrate_i * (Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
 	incrate_g[FEMALE] = incrate_i * incrr_sex[t]*(Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
       }
-      
+
       for(int hts = 0; hts < HIVSTEPS_PER_YEAR; hts++){
 
         int ts = (t-1)*HIVSTEPS_PER_YEAR + hts;
@@ -675,7 +675,7 @@ extern "C" {
 		cd4mx_scale = (hivpop[t][g][ha][hm] + artpop_hahm) > 0 ?
 		  hivpop[t][g][ha][hm] / (hivpop[t][g][ha][hm] + artpop_hahm) : 1.0;
 	      }
-	      
+
               double aids_deaths = cd4mx_scale * cd4_mort[g][ha][hm] * hivpop[t][g][ha][hm];
               hivdeaths_ha[g][ha] += DT * aids_deaths;
 	      aidsdeaths_noart[t][g][ha][hm] += DT * aids_deaths;
@@ -684,7 +684,7 @@ extern "C" {
               nonaids_excess_ha[g][ha] += DT * excess_nonaids_deaths;
 	      excessnonaidsdeaths_noart[t][g][ha][hm] += DT * excess_nonaids_deaths;
 
-	      
+
               grad[g][ha][hm] = -(aids_deaths + excess_nonaids_deaths);
             }
             for(int hm = 1; hm < hDS; hm++){
@@ -696,7 +696,7 @@ extern "C" {
         if (eppmod != EPP_DIRECTINCID_ANN) {
 
           // incidence
-          
+
           if (eppmod != EPP_DIRECTINCID_HTS) {
 
             // calculate r(t)
@@ -706,29 +706,29 @@ extern "C" {
               rvec[ts] = calc_rtrend_rt(pop, rtrend_tstab, rtrend_beta, rtrend_r0,
                                         projsteps[ts], tsEpidemicStart, DT, t, hts,
                                         rvec[ts-1], &prevlast, &prevcurr);
-            } 
-            
+            }
+
             // calculate new infections by sex and age
             calc_infections_eppspectrum(pop, hivpop, artpop,
                                         rvec[ts], relinfectART, (projsteps[ts] == tsEpidemicStart) ? iota : 0.0,
-                                        incrr_sex, incrr_age, 
+                                        incrr_sex, incrr_age,
                                         t_ART_start, DT, t, hts, hAG_START, hAG_SPAN,
                                         &prevcurr, &incrate15to49_ts_out[ts], infections_ts);
-          
+
             prev15to49_ts_out[ts] = prevcurr;
 
           } else { // eppmod == EPP_DIRECTINCID_HTS
-	    
+
 	    // Calculate HIV infections by age. This uses the updated
 	    // 'current year' population (vs. previous year population
 	    // used for overall incidence rate and incidence by sex)
-	    
+
 	    for(int g = 0; g < NG; g++) {
 	      double Xhivn_incagerr = 0.0;
 	      for(int a = pIDX_INCIDPOP; a < pIDX_INCIDPOP+pAG_INCIDPOP; a++) {
 		    Xhivn_incagerr += incrr_age[t][g][a] * pop[t][HIVN][g][a];
 	      }
-	      
+
 	      for(int a = 0; a < pAG; a++) {
 		infections_ts[g][a] = pop[t][HIVN][g][a] * incrate_g[g] * incrr_age[t][g][a] * Xhivn[g] / Xhivn_incagerr;
 	      }
@@ -761,7 +761,7 @@ extern "C" {
         if(t >= t_ART_start){
 
 	  double gradART[NG][hAG][hDS][hTS];
-	  
+
           // progression and mortality
           for(int g = 0; g < NG; g++)
             for(int ha = 0; ha < hAG; ha++)
@@ -814,7 +814,7 @@ extern "C" {
 	    // category (aggregated over all ages).
 
 	    double Xart_15plus = 0.0; // Total currently on ART
-		    
+
             double artelig_hahm[hAG_15PLUS][hDS];
 	    double artelig_hm[hDS];
 	    double Xartelig_15plus = 0.0;
@@ -825,10 +825,10 @@ extern "C" {
 	    // Initialise to zero
 	    memset(artelig_hm, 0, hDS * sizeof(double));
 	    memset(expect_mort_artelig_hm, 0, hDS * sizeof(double));
-	    	    
+
             for(int ha = hIDX_15PLUS; ha < hAG; ha++){
               for(int hm = everARTelig_idx; hm < hDS; hm++){
-		
+
 		if(hm >= anyelig_idx){
 
 		  // Specify proportion eligibly
@@ -846,7 +846,7 @@ extern "C" {
 		  expect_mort_artelig_hm[hm] += expect_mort_hahm;
 		  expect_mort_artelig15plus += expect_mort_hahm;
 		}
-		
+
                 for(int hu = 0; hu < hTS; hu++) {
                   Xart_15plus += artpop[t][g][ha][hm][hu] + DT * gradART[g][ha][hm][hu];
 		}
@@ -854,7 +854,7 @@ extern "C" {
 
               // if pw_artelig, add pregnant women to artelig_hahm population
               if(g == FEMALE && pw_artelig[t] > 0 && ha < hAG_FERT){
-		
+
                 double frr_pop_ha = 0;
                 for(int a =  hAG_START[ha]; a < hAG_START[ha]+hAG_SPAN[ha]; a++)
                   frr_pop_ha += pop[t][HIVN][g][a]; // add HIV- population
@@ -904,7 +904,7 @@ extern "C" {
 	      if (projection_period_int == PROJPERIOD_MIDYEAR) {
 		art_interp_w -= 0.5;
 	      }
-	      
+
               if(!art15plus_isperc[t-1][g] && !art15plus_isperc[t][g]){ // both numbers
                 artnum_hts = (1.0 - art_interp_w)*artnum15plus[t-1][g] + art_interp_w*artnum15plus[t][g];
               } else if(art15plus_isperc[t-1][g] && art15plus_isperc[t][g]){ // both percentages
@@ -955,7 +955,7 @@ extern "C" {
 		    artinit_hahm = hivpop[t][g][ha][hm] + DT * grad[g][ha][hm];
 		  grad[g][ha][hm] -= artinit_hahm / DT;
                   gradART[g][ha][hm][ART0MOS] += artinit_hahm / DT;
-		  artinit[t][g][ha][hm] += artinit_hahm; 
+		  artinit[t][g][ha][hm] += artinit_hahm;
                 }
 
             } else if(art_alloc_method == 4) {  // lowest CD4 first
@@ -974,13 +974,13 @@ extern "C" {
 
                   grad[g][ha][hm] -= artinit_hahm / DT;
                   gradART[g][ha][hm][ART0MOS] += artinit_hahm / DT;
-		  artinit[t][g][ha][hm] += artinit_hahm; 
+		  artinit[t][g][ha][hm] += artinit_hahm;
 		}
 		if(init_prop < 1.0)
 		  break;
 		artinit_hts -= init_prop * artelig_hm;
 	      }
-	      
+
 	    } else { // Use mixture of eligibility and expected mortality for initiation distribution
 
 	      // ART allocation step 1: allocate by CD4 stage
@@ -990,17 +990,17 @@ extern "C" {
 		  ( (1.0 - art_alloc_mxweight) * artelig_hm[hm] / Xartelig_15plus +
 		    art_alloc_mxweight * expect_mort_artelig_hm[hm] / expect_mort_artelig15plus);
 	      }
-	      
+
               for(int ha = hIDX_15PLUS; ha < hAG; ha++)
                 for(int hm = anyelig_idx; hm < hDS; hm++){
 
 		  // ART allocation step 2: within CD4 category, allocate
 		  // by age proportional to eligibility
 		  if (artelig_hm[hm] > 0.0) {
-		    
+
 		    double artinit_hahm = artinit_hm[hm] *
 		      artelig_hahm[ha-hIDX_15PLUS][hm] / artelig_hm[hm];
-		      
+
 		    if(artinit_hahm > artelig_hahm[ha-hIDX_15PLUS][hm])
 		      artinit_hahm = artelig_hahm[ha-hIDX_15PLUS][hm];
 		    if(artinit_hahm > hivpop[t][g][ha][hm] + DT * grad[g][ha][hm])
@@ -1018,7 +1018,7 @@ extern "C" {
 	      for(int hm = everARTelig_idx; hm < hDS; hm++)
 		for(int hu = 0; hu < hTS; hu++)
 		  artpop[t][g][ha][hm][hu] += DT*gradART[g][ha][hm][hu];
-	  
+
 	} // if(t >= t_ART_start)
 
 	for(int g = 0; g < NG; g++)
@@ -1029,7 +1029,7 @@ extern "C" {
 
 	// remove hivdeaths from pop
 	for(int g = 0; g < NG; g++){
-	  
+
 	  // sum HIV+ population size in each hivpop age group
 	  double hivpop_ha[hAG];
 	  int a = 0;
@@ -1040,7 +1040,7 @@ extern "C" {
 	      a++;
 	    }
 	  }
-	  
+
 	  // remove hivdeaths proportionally to age-distribution within each age group
 	  a = 0;
 	  for(int ha = 0; ha < hAG; ha++){
@@ -1061,7 +1061,7 @@ extern "C" {
 
       } // loop HIVSTEPS_PER_YEAR
 
-      
+
       if (eppmod == EPP_DIRECTINCID_ANN) {
 
 	// Calculating new infections by age (once per year)
@@ -1069,18 +1069,18 @@ extern "C" {
 	// Calculate HIV infections by age (once per year). This uses the updated
 	// 'current year' population (vs. previous year population used for
 	// overall incidence rate and incidence by sex)
-	
+
 	for(int g = 0; g < NG; g++) {
 	  double Xhivn_incagerr = 0.0;
 	  for(int a = pIDX_INCIDPOP; a < pIDX_INCIDPOP+pAG_INCIDPOP; a++) {
 	    Xhivn_incagerr += incrr_age[t][g][a] * pop[t][HIVN][g][a];
 	  }
-	  
+
 	  for(int a = 0; a < pAG; a++) {
 	    infections_ts[g][a] = pop[t][HIVN][g][a] * incrate_g[g] * incrr_age[t][g][a] * Xhivn[g] / Xhivn_incagerr;
 	  }
 	}
-        
+
 	for(int g = 0; g < NG; g++){
 	  int a = 0;
 	  for(int ha = 0; ha < hAG; ha++){
@@ -1094,7 +1094,7 @@ extern "C" {
 	    }
 	    if(ha < hIDX_15TO49+hAG_15TO49)
 	      incid15to49[t] += infections_ha;
-	    
+
 	    // add infections to hivpop
 	    for(int hm = 0; hm < hDS; hm++)
 	      hivpop[t][g][ha][hm] += infections_ha * cd4_initdist[g][ha][hm];
@@ -1104,15 +1104,15 @@ extern "C" {
 
       // Net migration for calendar-year projection option with end-year migration
       if (projection_period_int == PROJPERIOD_CALENDAR) {
-	  
+
 	for(int g = 0; g < NG; g++){
 	  int a = 0;
 	  for(int ha = 0; ha < hAG; ha++){
 	    double mig_ha = 0, hivpop_ha = 0;
 	    for(int i = 0; i < hAG_SPAN[ha]; i++){
-	      
+
 	      hivpop_ha += pop[t][HIVP][g][a];
-	      
+
 	      double migrate_a = netmigr[t][g][a] / (pop[t][HIVN][g][a] + pop[t][HIVP][g][a]);
 	      // double migrate_a = netmigr[t][g][a] * (1+Sx[t][g][a])/2.0 / (pop[t][HIVN][g][a] + pop[t][HIVP][g][a]);
 	      pop[t][HIVN][g][a] *= 1+migrate_a;
@@ -1121,7 +1121,7 @@ extern "C" {
 	      pop[t][HIVP][g][a] += hmig_a;
 	      a++;
 	    }
-	    
+
 	    // migration for hivpop
 	    double migrate_ha = hivpop_ha > 0 ? mig_ha / hivpop_ha : 0.0;
 	    for(int hm = 0; hm < hDS; hm++){
@@ -1134,7 +1134,7 @@ extern "C" {
 	} // loop over g
       } // if (projection_period_int == PROJPERIOD_CALENDAR)
 
-      
+
       // adjust population to match target population
       if(bin_popadjust){
         for(int g = 0; g < NG; g++){
@@ -1202,7 +1202,7 @@ extern "C" {
       double incid15to49_denom = (projection_period_int == PROJPERIOD_CALENDAR) ?
 	0.5 * (hivn15to49[t-1] + hivn15to49[t]) :
 	hivn15to49[t-1];
-      
+
       incid15to49[t] /= incid15to49_denom;
     }
 

--- a/tests/testthat/test_leapfrog.R
+++ b/tests/testthat/test_leapfrog.R
@@ -1,0 +1,138 @@
+theta_rhybrid <- c(-0.407503322169364, -2.76794181367538, -1.26018073624346, 1995.96447776502,
+                   -0.00307437171215574, 0.0114118307148102, 0.00760958379603691, 0.02,
+                   2.24103194827232, -0.0792123921862689, -5.01917961803606, 0.359444135205712,
+                   -6.10051517060137)
+
+expect_mod_equivalent <- function(mod, mod_expected) {
+  expect_equal(class(mod), class(mod_expected))
+  expect_equal(dim(mod), dim(mod_expected))
+  attribute_names <- setdiff(names(attributes(mod_expected)), c("dim", "class"))
+  known_missing_attributes <- c("natdeaths_noart", "natdeaths_art", "popadjust",
+                                "pregprevlag", "entrantprev")
+  known_different_attributes <- c("rvec_ts")
+  attribuites_to_check <- setdiff(
+    attribute_names,
+    c(known_missing_attributes, known_different_attributes))
+
+  for (attr_name in attribuites_to_check) {
+    expected <- attr(mod_expected, attr_name)
+    received <- attr(mod, attr_name)
+    if (is.array("expected")) {
+      expect_equal(dim(received), dim(expected), info = attr_name)
+    } else {
+      expect_equal(length(received), length(expected), info = attr_name)
+    }
+  }
+}
+
+test_that("can run convert transmission input fp into leapfrog params", {
+  pjnz <- system.file("extdata", "testpjnz", "Botswana2018.PJNZ", package = "eppasm")
+  inputs <- prepare_spec_fit(pjnz, 2025.5)
+
+  fp <- prep_fp_fitmod(inputs$Urban, eppmod = "rhybrid")
+  fp <- stats::update(fp, list=fnCreateParam(theta_rhybrid, fp))
+
+  params <- fp_to_leapfrog_params(fp)
+
+  expect_equal(params$projection_start_year, 1970)
+  expect_equal(params$sim_years, 48)
+  expect_equal(params$incidence_model_choice, 1L)
+  expect_true(length(params$transmission_rate_hts) > 0)
+  expect_true(any(params$transmission_rate_hts > 0))
+  expect_equal(class(params), "specfp")
+})
+
+test_that("can convert output from leapfrog into mod data", {
+  pjnz <- system.file("extdata", "testpjnz", "Botswana2018.PJNZ", package="eppasm")
+  params <- leapfrog::prepare_leapfrog_parameters(pjnz, use_coarse_age_groups = TRUE)
+
+  n_years <- dim(params$Sx)[length(dim(params$Sx))]
+  output_years <- seq(params$projection_start_year, params$projection_start_year + n_years - 1)
+  leapfrog_result <- leapfrog::run_model(params, "HivCoarseAgeStratification", output_years = output_years)
+
+  params$sim_years <- length(output_years)
+  params$proj_years <- params$sim_years
+  mod <- leapfrog_result_to_mod(leapfrog_result, params)
+
+  fp <- prepare_directincid(pjnz)
+  mod_expected <- simmod(fp, VERSION = "C")
+
+  expect_mod_equivalent(mod, mod_expected)
+})
+
+test_that("can run simmod with leapfrog direct incidence data", {
+  pjnz <- system.file("extdata", "testpjnz", "Botswana2018.PJNZ", package = "eppasm")
+  fp <- prepare_directincid(pjnz)
+
+  mod <- simmod(fp, VERSION = "leapfrog")
+  mod_expected <- simmod(fp, version = "C")
+
+  expect_mod_equivalent(mod, mod_expected)
+})
+
+test_that("can run simmod with leapfrog transmission input data", {
+  pjnz <- system.file("extdata", "testpjnz", "Botswana2018.PJNZ", package = "eppasm")
+  inputs <- prepare_spec_fit(pjnz, 2018.5)
+
+  fp <- prep_fp_fitmod(inputs$Urban, eppmod = "rhybrid")
+  fp <- stats::update(fp, list=fnCreateParam(theta_rhybrid, fp))
+
+  mod <- simmod(fp, VERSION = "leapfrog")
+  mod_expected <- simmod(fp, VERSION = "C")
+
+  expect_mod_equivalent(mod, mod_expected)
+
+  # Assert outputs are not all 0
+  expect_true(any(attr(mod, "hivpop") > 0))
+  expect_true(any(attr(mod, "artpop") > 0))
+  expect_true(any(attr(mod, "infections") > 0))
+
+  ## Assert padded to correct lengths with 0s
+  hivpop <- attr(mod, "hivpop")
+  expect_true(all(hivpop[,,,49] == 0))
+
+  hivpop <- attr(mod_expected, "hivpop")
+  expect_true(all(hivpop[,,,49] == 0))
+
+  incrate15to49_ts <- attr(mod, "incrate15to49_ts")
+  expect_true(all(incrate15to49_ts[471:480] == 0))
+
+  incrate15to49_ts <- attr(mod_expected, "incrate15to49_ts")
+  expect_true(all(incrate15to49_ts[471:480] == 0))
+})
+
+
+test_that("pad dim util works", {
+  x <- array(1:6, dim = c(2, 3))
+  padded <- pad_last_dim(x, 4)
+
+  expect_equal(dim(padded), c(2, 4))
+  expect_equal(padded[,1:3], x)
+  expect_true(all(padded[,4] == 0))
+
+  x <- array(1:24, dim = c(2, 3, 4))
+  padded <- pad_last_dim(x, 5)
+
+  expect_equal(dim(padded), c(2, 3, 5))
+  expect_equal(padded[,,1:4], x)
+  expect_true(all(padded[,,5] == 0))
+
+  # When no padding, nothing changes
+  x <- array(1:6, dim = c(2, 3))
+  padded <- pad_last_dim(x, 3)
+  expect_equal(x, padded)
+  padded <- pad_last_dim(x, 2)
+  expect_equal(x, padded)
+
+  # Works with a vector
+  x <- c(1, 2, 3, 4, 5)
+  padded <- pad_last_dim(x, 10)
+  expect_equal(padded, c(1, 2, 3, 4, 5, 0, 0, 0, 0, 0))
+
+  # Works with matrix
+  x <- matrix(1:6, nrow = 3, ncol = 2)
+  padded <- pad_last_dim(x, 5)
+  expect_equal(dim(padded), c(3, 5))
+  expect_equal(padded[,1:2], x)
+  expect_true(all(padded[,3:5] == 0))
+})


### PR DESCRIPTION
There are some outstanding issues here we need to fix before we send this out
1. I've broken the existing tests
2. The model with transmission input test is returning all 0s for the HIV model
3. There is a cyclic dependency between leapfrog and eppasm (leapfrog uses eppasm to read data, eppasm uses leapfrog to fit the model) We can fix this when we can integrate @M-Kusumgar's reading changes into leapfrog
4. Fitting model with leapfrog is not working